### PR TITLE
Allow specifing the pane id for the read_terminal_tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
       {
         name: "read_terminal_output",
-        description: "Reads output from the active WezTerm pane",
+        description: "Reads output from the active WezTerm pane or a specific pane",
         inputSchema: {
           type: "object",
           properties: {
@@ -51,6 +51,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
               type: "number",
               description:
                 "Number of lines to read from the terminal (default: 50)",
+            },
+            pane_id: {
+              type: "number",
+              description:
+                "ID of the pane to read from (optional, defaults to current pane)",
             },
           },
         },
@@ -126,7 +131,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request: any) => {
 
     case "read_terminal_output":
       const lines = request.params.arguments.lines || 50;
-      return await outputReader.readOutput(lines);
+      const paneId = request.params.arguments.pane_id;
+      return await outputReader.readOutput(lines, paneId);
 
     case "send_control_character":
       return await controlCharSender.send(request.params.arguments.character);

--- a/src/wezterm_output_reader.ts
+++ b/src/wezterm_output_reader.ts
@@ -10,17 +10,18 @@ export default class WeztermOutputReader {
     this.weztermCli = "wezterm cli";
   }
 
-  async readOutput(lines: number = 50): Promise<{ content: any[] }> {
+  async readOutput(lines: number = 50, paneId?: number): Promise<{ content: any[] }> {
     try {
       let command: string;
+      const paneOption = paneId !== undefined ? ` --pane-id ${paneId}` : '';
 
       if (lines <= 0) {
         // 全ての内容を取得（現在の画面のみ）
-        command = `${this.weztermCli} get-text --escapes`;
+        command = `${this.weztermCli} get-text --escapes${paneOption}`;
       } else {
         // 指定された行数分を取得（スクロールバックから）
         const startLine = -lines;
-        command = `${this.weztermCli} get-text --escapes --start-line ${startLine}`;
+        command = `${this.weztermCli} get-text --escapes --start-line ${startLine}${paneOption}`;
       }
 
       const { stdout } = await execAsync(command);
@@ -46,10 +47,11 @@ export default class WeztermOutputReader {
   }
 
   // 現在の画面内容のみを取得する新しいメソッド
-  async readCurrentScreen(): Promise<{ content: any[] }> {
+  async readCurrentScreen(paneId?: number): Promise<{ content: any[] }> {
     try {
+      const paneOption = paneId !== undefined ? ` --pane-id ${paneId}` : '';
       const { stdout } = await execAsync(
-        `${this.weztermCli} get-text --escapes`
+        `${this.weztermCli} get-text --escapes${paneOption}`
       );
 
       return {

--- a/tests/wezterm_output_reader.test.ts
+++ b/tests/wezterm_output_reader.test.ts
@@ -102,6 +102,51 @@ describe("WeztermOutputReader", () => {
       expect(result.content[0].text).toContain("WezTerm connection failed");
       expect(result.content[0].text).toContain("wezterm cli list");
     });
+
+    it("should read output from specific pane when pane_id is provided", async () => {
+      const mockOutput = "pane specific output";
+      mockedExec.mockImplementation((command: string, callback: any) => {
+        expect(command).toContain("get-text --escapes --start-line -30 --pane-id 123");
+        callback(null, { stdout: mockOutput, stderr: "" });
+        return {} as any;
+      });
+
+      const result = await outputReader.readOutput(30, 123);
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe("text");
+      expect(result.content[0].text).toBe(mockOutput);
+    });
+
+    it("should not include --pane-id option when pane_id is not provided", async () => {
+      const mockOutput = "default pane output";
+      mockedExec.mockImplementation((command: string, callback: any) => {
+        expect(command).toContain("get-text --escapes --start-line -25");
+        expect(command).not.toContain("--pane-id");
+        callback(null, { stdout: mockOutput, stderr: "" });
+        return {} as any;
+      });
+
+      const result = await outputReader.readOutput(25);
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].text).toBe(mockOutput);
+    });
+
+    it("should include --pane-id option and exclude --start-line when pane_id is provided with 0 or negative lines", async () => {
+      const mockOutput = "full screen from specific pane";
+      mockedExec.mockImplementation((command: string, callback: any) => {
+        expect(command).toContain("get-text --escapes --pane-id 456");
+        expect(command).not.toContain("--start-line");
+        callback(null, { stdout: mockOutput, stderr: "" });
+        return {} as any;
+      });
+
+      const result = await outputReader.readOutput(0, 456);
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].text).toBe(mockOutput);
+    });
   });
 
   describe("readCurrentScreen", () => {
@@ -146,6 +191,38 @@ describe("WeztermOutputReader", () => {
       expect(result.content[0].type).toBe("text");
       expect(result.content[0].text).toContain("Failed to read current screen");
       expect(result.content[0].text).toContain("Screen read failed");
+    });
+
+    it("should read current screen from specific pane when pane_id is provided", async () => {
+      const mockScreenContent = "specific pane screen content";
+      mockedExec.mockImplementation((command: string, callback: any) => {
+        expect(command).toContain("get-text --escapes --pane-id 789");
+        expect(command).not.toContain("--start-line");
+        callback(null, { stdout: mockScreenContent, stderr: "" });
+        return {} as any;
+      });
+
+      const result = await outputReader.readCurrentScreen(789);
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe("text");
+      expect(result.content[0].text).toBe(mockScreenContent);
+    });
+
+    it("should not include --pane-id option in readCurrentScreen when pane_id is not provided", async () => {
+      const mockScreenContent = "default pane screen content";
+      mockedExec.mockImplementation((command: string, callback: any) => {
+        expect(command).toContain("get-text --escapes");
+        expect(command).not.toContain("--pane-id");
+        expect(command).not.toContain("--start-line");
+        callback(null, { stdout: mockScreenContent, stderr: "" });
+        return {} as any;
+      });
+
+      const result = await outputReader.readCurrentScreen();
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].text).toBe(mockScreenContent);
     });
   });
 });


### PR DESCRIPTION
Thanks for making this. It is a lot of fun.

I wanted to allow Claude Code to read a background tabs output without having to switch to it. It should all be backwards compatible.